### PR TITLE
Only split and push specified tag

### DIFF
--- a/src/Command/SplitCommand.php
+++ b/src/Command/SplitCommand.php
@@ -37,9 +37,9 @@ class SplitCommand extends Command
             ->setName('split')
             ->setDescription('Split monorepo into repositories by subfolder.')
             ->addArgument(
-                'branch',
+                'branch-or-tag',
                 InputArgument::OPTIONAL,
-                'Which branch should be split, defaults to all branches that match the configured branch filter.'
+                'Which branch or tag should be split, defaults to all branches that match the configured branch filter.'
             )
             ->addOption(
                 'cache-dir',
@@ -77,7 +77,7 @@ class SplitCommand extends Command
             $config['repositories'],
             $input->getOption('cache-dir') ?: $this->rootDir.'/.monorepo-split-cache',
             $input->getOption('force-push'),
-            $input->getArgument('branch'),
+            $input->getArgument('branch-or-tag'),
             $output
         );
 

--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -96,11 +96,21 @@ class Repository
         return $this;
     }
 
-    public function fetchTags(string $remote, string $prefix)
+    public function fetchTags(string $remote, string $prefix): self
     {
         $this->execute(
             'git --git-dir='.escapeshellarg($this->path).' fetch --no-tags '.escapeshellarg($remote).' '
             .escapeshellarg('+refs/tags/*:refs/tags/'.$prefix.'*')
+        );
+
+        return $this;
+    }
+
+    public function fetchTag(string $tag, string $remote, string $prefix): self
+    {
+        $this->execute(
+            'git --git-dir='.escapeshellarg($this->path).' fetch --no-tags '.escapeshellarg($remote).' '
+            .escapeshellarg('+refs/tags/'.$tag.':refs/tags/'.$prefix.$tag)
         );
 
         return $this;
@@ -139,6 +149,17 @@ class Repository
         }
 
         return $tags;
+    }
+
+    public function getTag(string $tag): string
+    {
+        $result = $this->run('git --git-dir='.escapeshellarg($this->path).' rev-list -n 1 '.escapeshellarg($tag));
+
+        if (!\count($result) || \strlen($result[0]) !== 40) {
+            throw new \RuntimeException(sprintf('Tag %s not found.', $tag));
+        }
+
+        return $result[0];
     }
 
     public function addTag(string $name, string $hash): self


### PR DESCRIPTION
With this change only the specified tag gets split and pushed.

The only thing we should have to change in the travis config is adding `tag IS present` to the split condition:  
`type = push AND (branch =~ /^(master|\d+\.\d+)$/ OR tag IS present)`

`$TRAVIS_BRANCH` already points to the tag name, so we don’t have to change something here.

/cc @leofeyer 