### PR TITLE
Improve error message when using validate

### DIFF
--- a/src/Command/ComposerJsonCommand.php
+++ b/src/Command/ComposerJsonCommand.php
@@ -93,6 +93,7 @@ class ComposerJsonCommand extends Command
                 );
 
                 $io->error('The following files are not up to date: '.implode(',', $files));
+                $io->writeln('Run this command without the --validate option to apply updates accordingly.');
             }
         } else {
             $updated = $this->updateJsons($rootJson, $splitJsons);


### PR DESCRIPTION
The composer script inside `contao/contao` called `composer-json` runs the according command with the `--validate` option.  That's correct :smile: but it would be helpful if the command would be a bit more helpful in case of an error (files not in sync). This way developers would know what to do.