### PR TITLE
Show diff for invalid composer jsons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "ext-json": "*",
         "ext-zlib": "*",
         "composer/semver": "^1.0",
+        "phpspec/php-diff": "^1.0",
         "symfony/config": "^3.4 || ^4.0 || ^5.0",
         "symfony/console": "^3.4 || ^4.0 || ^5.0",
         "symfony/filesystem": "^3.4 || ^4.0 || ^5.0",

--- a/src/Command/ComposerJsonCommand.php
+++ b/src/Command/ComposerJsonCommand.php
@@ -97,6 +97,13 @@ class ComposerJsonCommand extends Command
 
             $io->error('The following files are not up to date: '.implode(',', $files));
 
+            foreach ($invalid as $path => $newJson) {
+                $a = explode("\n", file_get_contents($path));
+                $b = explode("\n", $newJson);
+                $io->writeln($path);
+                $io->writeln((new \Diff($a, $b))->render(new \Diff_Renderer_Text_Unified()));
+            }
+
             return 1;
         }
 


### PR DESCRIPTION
This should improve the error message `The following files are not up to date` by showing a diff of the required changes.

Should be helpful especially if the error only occurs on the CI.