### PR TITLE
Implemented better constraint merging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "ext-zlib": "*",
-        "composer/semver": "^1.0",
+        "composer/semver": "^3.2",
         "phpspec/php-diff": "^1.0",
         "symfony/config": "^3.4 || ^4.0 || ^5.0",
         "symfony/console": "^3.4 || ^4.0 || ^5.0",


### PR DESCRIPTION
Based on @Toflar​s #13 this version reuses the pretty version constraints from the existing JSON files. This way the style of the version constraints are completely up to the project maintainers.

“New” version constraints that don’t exist yet will still look something like `>= 4.4.20.0-dev < 4.5.0.0-dev || >= 5.2.0.0-dev < 5.3.0.0-dev` but you can replace them with `~4.4.20 || 5.2.*` and the composer.json still validates.