### PR TITLE
Version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+
+## [0.1.0] (2024-03-27)
+
  * Initial release.
 
-[Unreleased]: https://github.com/contao/monorepo-tools/commits
+[Unreleased]: https://github.com/contao/monorepo-tools/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/contao/monorepo-tools/commits/0.1.0

--- a/composer.json
+++ b/composer.json
@@ -67,5 +67,10 @@
         "unit-tests": [
             "vendor/bin/phpunit --colors=always"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
Before merging the bigger changes from #20 I think it is a good idea to release a version with the current status so that users can switch back to 0.1.0 if we break things.