### PR TITLE
Ignore HEAD branches in the `getRemoteBranches()` method

### DIFF
--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -128,7 +128,7 @@ class Repository
         foreach ($this->run(['git', '--git-dir='.$this->path, 'branch', '-r']) as $branch) {
             $branch = trim($branch);
 
-            if ('' === $branch || !str_starts_with($branch, $remote.'/')) {
+            if ('' === $branch || str_contains($branch, '->') || !str_starts_with($branch, $remote.'/')) {
                 continue;
             }
 


### PR DESCRIPTION
This is the result of `git branch -r` on GitHub:

```
mono/4.13
mono/5.3
mono/5.5
mono/5.x
mono/HEAD -> mono/5.x
```

After merging the PR, the last line will be ignored. But maybe you can think of a better fix? We could pass the branch filter for example.