### PR TITLE
Use ls-remote command to list remote branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+ *  Use ls-remote command to list remote branches. [#30]
 
 ## [0.2.0] (2024-03-27)
 
@@ -18,5 +19,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [0.2.0]: https://github.com/contao/monorepo-tools/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/contao/monorepo-tools/commits/0.1.0
 
+[#30]: https://github.com/contao/monorepo-tools/issues/30
 [#22]: https://github.com/contao/monorepo-tools/issues/22
 [#20]: https://github.com/contao/monorepo-tools/issues/20

--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -125,15 +125,15 @@ class Repository
     {
         $branches = [];
 
-        foreach ($this->run(['git', '--git-dir='.$this->path, 'branch', '-r']) as $branch) {
-            $branch = trim($branch);
+        foreach ($this->run(['git', '--git-dir='.$this->path, 'ls-remote', '--heads', $remote]) as $line) {
+            [$commit, $branch] = explode("\t", trim($line)) + ['', ''];
 
-            if ('' === $branch || !str_starts_with($branch, $remote.'/')) {
+            if (40 !== \strlen($commit) || !str_starts_with($branch, 'refs/heads/')) {
                 continue;
             }
 
-            $branch = substr($branch, \strlen($remote.'/'));
-            $branches[$branch] = $this->run(['git', '--git-dir='.$this->path, 'rev-parse', $remote.'/'.$branch])[0];
+            $branch = substr($branch, \strlen('refs/heads/'));
+            $branches[$branch] = $commit;
         }
 
         return $branches;


### PR DESCRIPTION
This should fix the error `fatal: ambiguous argument 'mono/HEAD -> mono/5.x': unknown revision or path not in the working tree` that is caused by the output of `branch -r`

Alternative to #29